### PR TITLE
Switch repo.gate.ac.uk references to https

### DIFF
--- a/gate-asm/pom.xml
+++ b/gate-asm/pom.xml
@@ -105,7 +105,7 @@
 		<snapshotRepository>
 			<id>gate.snapshots</id>
 			<name>GATE Snapshots Repository</name>
-			<url>http://repo.gate.ac.uk/content/repositories/snapshots</url>
+			<url>https://repo.gate.ac.uk/content/repositories/snapshots</url>
 			<layout>default</layout>
 		</snapshotRepository>
 	</distributionManagement>

--- a/gate-compiler-jdt/pom.xml
+++ b/gate-compiler-jdt/pom.xml
@@ -122,7 +122,7 @@
 		<snapshotRepository>
 			<id>gate.snapshots</id>
 			<name>GATE Snapshots Repository</name>
-			<url>http://repo.gate.ac.uk/content/repositories/snapshots</url>
+			<url>https://repo.gate.ac.uk/content/repositories/snapshots</url>
 			<layout>default</layout>
 		</snapshotRepository>
 	</distributionManagement>

--- a/gate-plugin-base/pom.xml
+++ b/gate-plugin-base/pom.xml
@@ -71,7 +71,7 @@
 		<repository>
 			<id>gate.ac.uk</id>
 			<name>GATE Development Repository</name>
-			<url>http://repo.gate.ac.uk/content/groups/public/</url>
+			<url>https://repo.gate.ac.uk/content/groups/public/</url>
 		</repository>
 	</repositories>
 
@@ -79,7 +79,7 @@
 		<pluginRepository>
 			<id>gate.ac.uk</id>
 			<name>GATE Development Repository</name>
-			<url>http://repo.gate.ac.uk/content/groups/public/</url>
+			<url>https://repo.gate.ac.uk/content/groups/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
 

--- a/gate-plugin-test-utils/pom.xml
+++ b/gate-plugin-test-utils/pom.xml
@@ -59,7 +59,7 @@
 		<repository>
 			<id>gate.ac.uk</id>
 			<name>GATE Development Repository</name>
-			<url>http://repo.gate.ac.uk/content/groups/public/</url>
+			<url>https://repo.gate.ac.uk/content/groups/public/</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Recent versions of Maven (3.8.1+) block http: repositories by default, allowing only https:.  Since gate-plugin-base contributes repositories to any plugin that inherits from it, our reference to the http: version of `repo.gate.ac.uk` causes a multitude of build warnings and failure to download dependencies.  It should be safe to switch the reference to https: as everything served at the http: URLs of `repo.gate.ac.uk` is also served as https: