### PR TITLE
Upgrade GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout Master Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
         continue-on-error: true
         # This step may error out when run in a fork that doesn't have pages
         # enabled - if this happens, run the rest but skip anything that
@@ -40,7 +40,7 @@ jobs:
         # to subsequent steps, so we can condition on that.
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload artifact
         if: env.GITHUB_PAGES == 'true'
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: 'target/staging'
@@ -136,4 +136,4 @@ jobs:
       - name: Deploy site to GitHub Pages
         if: env.GITHUB_PAGES == 'true'
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload Test Results
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: |
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}

--- a/.github/workflows/standard-module-pr.yml
+++ b/.github/workflows/standard-module-pr.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Update submodules if necessary
         run: |
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}

--- a/.github/workflows/standard-module-pr.yml
+++ b/.github/workflows/standard-module-pr.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload Test Results
         if: inputs.test_report && (success() || failure())
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: |
@@ -122,7 +122,7 @@ jobs:
     if: inputs.test_report
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}

--- a/.github/workflows/standard-module.yml
+++ b/.github/workflows/standard-module.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Setup Pages
         if: inputs.deploy_site_to_pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
         continue-on-error: true
         # This step may error out when run in a fork that doesn't have pages
         # enabled - if this happens, run the rest but skip anything that
@@ -76,7 +76,7 @@ jobs:
         # to subsequent steps, so we can condition on that.
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}

--- a/.github/workflows/standard-module.yml
+++ b/.github/workflows/standard-module.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Upload artifact
         if: github.ref == inputs.default_branch && env.GITHUB_PAGES == 'true'
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: 'target/site'
@@ -173,4 +173,4 @@ jobs:
       - name: Deploy site to GitHub Pages
         if: github.ref == inputs.default_branch && env.GITHUB_PAGES == 'true'
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- upgrade uses of `upload-artifact` to v4, as v3 is deprecated
  - this includes indirect uses via `upload-pages-artifact`
- upgrade other actions that have newer releases